### PR TITLE
Remove react from peerDependencies to prevent duplicate react bundling

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,6 @@
     "url": "https://github.com/saulhoward/react-evil-icons/issues"
   },
   "homepage": "https://github.com/saulhoward/react-evil-icons",
-  "peerDependencies": {
-    "react": ">=0.12.2"
-  },
   "dependencies": {
     "gulp": "^3.8.11",
     "gulp-inject-string": "0.0.2",


### PR DESCRIPTION
Hi! I'm working on some component with react-evil-icons as dependency in it. And today I discovered that if react is defined in peerDependencies then it using twice with errors like 'Cannot read property 'firstChild' of undefined'. (tested with browserify & webpack)
I think it's better to just remove it from peerDependencies :)